### PR TITLE
Add PyTorch Lightning CIFAR-10 demo

### DIFF
--- a/vision/image_classification.ipynb
+++ b/vision/image_classification.ipynb
@@ -1,25 +1,223 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "e4a2b4e6",
+   "metadata": {},
+   "source": [
+    "# Image Classification with PyTorch Lightning\n",
+    "This notebook demonstrates how to train a ResNet-50 model on the CIFAR-10 dataset using [PyTorch Lightning](https://www.pytorchlightning.ai/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7329ebfd",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Install and import required libraries."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4acb9561",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "id": "e4aa26fa",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "Hello World"
+    "import torch\n",
+    "import torchvision\n",
+    "from torchvision import transforms, datasets, models\n",
+    "import pytorch_lightning as pl\n",
+    "from torch.utils.data import random_split, DataLoader\n",
+    "import torch.nn as nn\n",
+    "import torchmetrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cca25804",
+   "metadata": {},
+   "source": [
+    "## Data Loading\n",
+    "Download the CIFAR-10 dataset and split it into training, validation, and test sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28b0b7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "class CIFAR10DataModule(pl.LightningDataModule):\n",
+    "    def __init__(self, data_dir='./data', batch_size=64):\n",
+    "        super().__init__()\n",
+    "        self.data_dir = data_dir\n",
+    "        self.batch_size = batch_size\n",
+    "        self.transform = transforms.Compose([\n",
+    "            transforms.ToTensor(),\n",
+    "            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))\n",
+    "        ])\n",
+    "\n",
+    "    def prepare_data(self):\n",
+    "        datasets.CIFAR10(self.data_dir, train=True, download=True)\n",
+    "        datasets.CIFAR10(self.data_dir, train=False, download=True)\n",
+    "\n",
+    "    def setup(self, stage=None):\n",
+    "        if stage == 'fit' or stage is None:\n",
+    "            full_train = datasets.CIFAR10(self.data_dir, train=True, transform=self.transform)\n",
+    "            self.train_set, self.val_set = random_split(full_train, [45000, 5000])\n",
+    "        if stage == 'test' or stage is None:\n",
+    "            self.test_set = datasets.CIFAR10(self.data_dir, train=False, transform=self.transform)\n",
+    "\n",
+    "    def train_dataloader(self):\n",
+    "        return DataLoader(self.train_set, batch_size=self.batch_size, shuffle=True)\n",
+    "\n",
+    "    def val_dataloader(self):\n",
+    "        return DataLoader(self.val_set, batch_size=self.batch_size)\n",
+    "\n",
+    "    def test_dataloader(self):\n",
+    "        return DataLoader(self.test_set, batch_size=self.batch_size)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc0ab1bc",
+   "metadata": {},
+   "source": [
+    "## Model\n",
+    "Define a LightningModule wrapping a ResNet-50 model for classification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "025f67ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "class LitResNet(pl.LightningModule):\n",
+    "    def __init__(self, lr=1e-3):\n",
+    "        super().__init__()\n",
+    "        self.save_hyperparameters()\n",
+    "        self.model = models.resnet50(weights=None, num_classes=10)\n",
+    "        self.criterion = nn.CrossEntropyLoss()\n",
+    "        self.accuracy = torchmetrics.classification.MulticlassAccuracy(num_classes=10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        x, y = batch\n",
+    "        logits = self.forward(x)\n",
+    "        loss = self.criterion(logits, y)\n",
+    "        acc = self.accuracy(logits.softmax(dim=-1), y)\n",
+    "        self.log('train_loss', loss)\n",
+    "        self.log('train_acc', acc, prog_bar=True)\n",
+    "        return loss\n",
+    "\n",
+    "    def validation_step(self, batch, batch_idx):\n",
+    "        x, y = batch\n",
+    "        logits = self.forward(x)\n",
+    "        loss = self.criterion(logits, y)\n",
+    "        acc = self.accuracy(logits.softmax(dim=-1), y)\n",
+    "        self.log('val_loss', loss, prog_bar=True)\n",
+    "        self.log('val_acc', acc, prog_bar=True)\n",
+    "\n",
+    "    def test_step(self, batch, batch_idx):\n",
+    "        x, y = batch\n",
+    "        logits = self.forward(x)\n",
+    "        loss = self.criterion(logits, y)\n",
+    "        acc = self.accuracy(logits.softmax(dim=-1), y)\n",
+    "        self.log('test_loss', loss)\n",
+    "        self.log('test_acc', acc)\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf90dd8a",
+   "metadata": {},
+   "source": [
+    "## Training\n",
+    "Create the datamodule and model, then fit using the PyTorch Lightning trainer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d16346e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "data_module = CIFAR10DataModule()\n",
+    "model = LitResNet()\n",
+    "trainer = pl.Trainer(max_epochs=1)\n",
+    "trainer.fit(model, data_module)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c396185",
+   "metadata": {},
+   "source": [
+    "## Evaluation\n",
+    "Evaluate the trained model on the test set and display metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "496ed281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "results = trainer.test(model, datamodule=data_module)\n",
+    "print(results)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec52fb50",
+   "metadata": {},
+   "source": [
+    "You can visualize the results further using a confusion matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cc2653a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay\n",
+    "\n",
+    "preds, targets = [], []\n",
+    "for batch in data_module.test_dataloader():\n",
+    "    x, y = batch\n",
+    "    logits = model(x)\n",
+    "    preds.append(logits.argmax(dim=1))\n",
+    "    targets.append(y)\n",
+    "\n",
+    "preds = torch.cat(preds)\n",
+    "targets = torch.cat(targets)\n",
+    "cm = confusion_matrix(targets.numpy(), preds.numpy())\n",
+    "ConfusionMatrixDisplay(cm).plot()\n",
+    "plt.show()\n"
    ]
   }
  ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- add an end-to-end example notebook in `vision/image_classification.ipynb` using PyTorch Lightning
- load the CIFAR-10 dataset with train/val/test splits
- train a ResNet-50 model and evaluate metrics
- show how to plot a confusion matrix

## Testing
- `pytest -q`
